### PR TITLE
allow python-dateutil >= 1.5 instead of only == 1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 oauth2==1.5.211
 requests==0.14.0
-python-dateutil==1.5
+python-dateutil>=1.5


### PR DESCRIPTION
The latest version of `python-dateutil` is both python2 and python3 compatible via the `six` package.

All the tests passed when I changed this locally.

This change will allow `python-fitbit` to play nice with a lot of newer packages.
