### PR TITLE
include the error messages in the exception

### DIFF
--- a/fitbit/exceptions.py
+++ b/fitbit/exceptions.py
@@ -1,4 +1,4 @@
-
+import json
 
 class BadResponse(Exception):
     """
@@ -14,7 +14,12 @@ class DeleteError(Exception):
 
 class HTTPException(Exception):
     def __init__(self, response, *args, **kwargs):
-        super(HTTPException, self).__init__(*args, **kwargs)
+        try:
+            errors = json.loads(response.content)['errors']
+            message = '\n'.join([error['message'] for error in errors])
+        except Exception:
+            message = response
+        super(HTTPException, self).__init__(message, *args, **kwargs)
 
 class HTTPBadRequest(HTTPException):
     pass


### PR DESCRIPTION
We were passing the response to the constructor, but it wasn't being used. This attempts to get the error messages from the response and use them for the exception message, otherwise the response object itself is used.
@percyperez can you check my work?
