### PR TITLE
Adds support for get_bodyweight and get_bodyfat.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Rebecca Lovewell (Caktus Consulting Group)
 Dan Poirier (Caktus Consulting Group)
 Brad Pitcher (ORCAS)
 Silvio Tomatis
+Steven Skoczen

--- a/fitbit/__init__.py
+++ b/fitbit/__init__.py
@@ -17,7 +17,7 @@ __author_email__ = 'bpitcher@orcasinc.com'
 __copyright__ = 'Copyright 2012 ORCAS'
 __license__ = 'Apache 2.0'
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 
 # Module namespace.
 

--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -686,6 +686,118 @@ class Fitbit(object):
         )
         return self.make_request(url)
 
+    def get_bodyweight(self, base_date=None, user_id=None, period=None, end_date=None):
+        """
+        https://wiki.fitbit.com/display/API/API-Get-Body-Weight
+        base_date should be a datetime.date object (defaults to today),
+        period can be '1d', '7d', '30d', '1w', '1m', '3m', '6m', '1y', 'max' or None
+        end_date should be a datetime.date object, or None.
+
+        You can specify period or end_date, or neither, but not both.
+        """
+        if not base_date:
+            base_date = datetime.date.today()
+
+        if not user_id:
+            user_id = '-'
+
+        if period and end_date:
+            raise TypeError("Either end_date or period can be specified, not both")
+
+        if not isinstance(base_date, basestring):
+            base_date_string = base_date.strftime('%Y-%m-%d')
+        else:
+            base_date_string = base_date
+
+        if period:
+            if not period in ['1d', '7d', '30d', '1w', '1m', '3m', '6m', '1y', 'max']:
+                raise ValueError("Period must be one of '1d', '7d', '30d', '1w', '1m', '3m', '6m', '1y', 'max'")
+
+            url = "%s/%s/user/%s/body/log/weight/date/%s/%s.json" % (
+                self.API_ENDPOINT,
+                self.API_VERSION,
+                user_id,
+                base_date_string,
+                period
+            )
+        elif end_date:
+            if not isinstance(end_date, basestring):
+                end_string = end_date.strftime('%Y-%m-%d')
+            else:
+                end_string = end_date
+
+            url = "%s/%s/user/%s/body/log/weight/date/%s/%s.json" % (
+                self.API_ENDPOINT,
+                self.API_VERSION,
+                user_id,
+                base_date_string,
+                end_string
+            )
+        else:
+            url = "%s/%s/user/%s/body/log/weight/date/%s.json" % (
+                self.API_ENDPOINT,
+                self.API_VERSION,
+                user_id,
+                base_date_string,
+            )
+        return self.make_request(url)
+
+    def get_bodyfat(self, base_date=None, user_id=None, period=None, end_date=None):
+        """
+        https://wiki.fitbit.com/display/API/API-Get-Body-fat
+        base_date should be a datetime.date object (defaults to today),
+        period can be '1d', '7d', '30d', '1w', '1m', '3m', '6m', '1y', 'max' or None
+        end_date should be a datetime.date object, or None.
+
+        You can specify period or end_date, or neither, but not both.
+        """
+        if not base_date:
+            base_date = datetime.date.today()
+
+        if not user_id:
+            user_id = '-'
+
+        if period and end_date:
+            raise TypeError("Either end_date or period can be specified, not both")
+
+        if not isinstance(base_date, basestring):
+            base_date_string = base_date.strftime('%Y-%m-%d')
+        else:
+            base_date_string = base_date
+
+        if period:
+            if not period in ['1d', '7d', '30d', '1w', '1m', '3m', '6m', '1y', 'max']:
+                raise ValueError("Period must be one of '1d', '7d', '30d', '1w', '1m', '3m', '6m', '1y', 'max'")
+
+            url = "%s/%s/user/%s/body/log/fat/date/%s/%s.json" % (
+                self.API_ENDPOINT,
+                self.API_VERSION,
+                user_id,
+                base_date_string,
+                period
+            )
+        elif end_date:
+            if not isinstance(end_date, basestring):
+                end_string = end_date.strftime('%Y-%m-%d')
+            else:
+                end_string = end_date
+
+            url = "%s/%s/user/%s/body/log/fat/date/%s/%s.json" % (
+                self.API_ENDPOINT,
+                self.API_VERSION,
+                user_id,
+                base_date_string,
+                end_string
+            )
+        else:
+            url = "%s/%s/user/%s/body/log/fat/date/%s.json" % (
+                self.API_ENDPOINT,
+                self.API_VERSION,
+                user_id,
+                base_date_string,
+            )
+        return self.make_request(url)
+
     def get_friends(self, user_id=None):
         """
         https://wiki.fitbit.com/display/API/API-Get-Friends

--- a/fitbit_tests/test_api.py
+++ b/fitbit_tests/test_api.py
@@ -292,6 +292,50 @@ class MiscTest(TestBase):
         url = "%s/%s/activities/FOOBAR.json" % (Fitbit.API_ENDPOINT, Fitbit.API_VERSION)
         self.common_api_test('activity_detail', ("FOOBAR",), {}, (url,), {})
 
+    def test_bodyweight(self):
+        def test_get_bodyweight(fb, base_date=None, user_id=None, period=None, end_date=None, expected_url=None):
+            with mock.patch.object(fb, 'make_request') as make_request:
+                fb.get_bodyweight(base_date, user_id=user_id, period=period, end_date=end_date)
+            args, kwargs = make_request.call_args
+            self.assertEqual((expected_url,), args)
+
+        user_id = 'BAR'
+
+        # No end_date or period
+        test_get_bodyweight(self.fb, base_date=datetime.date(1992, 5, 12), user_id=None, period=None, end_date=None,
+            expected_url=URLBASE + "/-/body/log/weight/date/1992-05-12.json")
+        # With end_date
+        test_get_bodyweight(self.fb, base_date=datetime.date(1992, 5, 12), user_id=user_id, period=None, end_date=datetime.date(1998, 12, 31),
+            expected_url=URLBASE + "/BAR/body/log/weight/date/1992-05-12/1998-12-31.json")
+        # With period
+        test_get_bodyweight(self.fb, base_date=datetime.date(1992, 5, 12), user_id=user_id, period="1d", end_date=None,
+            expected_url=URLBASE + "/BAR/body/log/weight/date/1992-05-12/1d.json")
+        # Date defaults to today
+        test_get_bodyweight(self.fb, base_date=None, user_id=None, period=None, end_date=None,
+            expected_url=URLBASE + "/-/body/log/weight/date/%s.json" % datetime.date.today().strftime('%Y-%m-%d'))
+
+    def test_bodyfat(self):
+        def test_get_bodyfat(fb, base_date=None, user_id=None, period=None, end_date=None, expected_url=None):
+            with mock.patch.object(fb, 'make_request') as make_request:
+                fb.get_bodyfat(base_date, user_id=user_id, period=period, end_date=end_date)
+            args, kwargs = make_request.call_args
+            self.assertEqual((expected_url,), args)
+
+        user_id = 'BAR'
+
+        # No end_date or period
+        test_get_bodyfat(self.fb, base_date=datetime.date(1992, 5, 12), user_id=None, period=None, end_date=None,
+            expected_url=URLBASE + "/-/body/log/fat/date/1992-05-12.json")
+        # With end_date
+        test_get_bodyfat(self.fb, base_date=datetime.date(1992, 5, 12), user_id=user_id, period=None, end_date=datetime.date(1998, 12, 31),
+            expected_url=URLBASE + "/BAR/body/log/fat/date/1992-05-12/1998-12-31.json")
+        # With period
+        test_get_bodyfat(self.fb, base_date=datetime.date(1992, 5, 12), user_id=user_id, period="1d", end_date=None,
+            expected_url=URLBASE + "/BAR/body/log/fat/date/1992-05-12/1d.json")
+        # Date defaults to today
+        test_get_bodyfat(self.fb, base_date=None, user_id=None, period=None, end_date=None,
+            expected_url=URLBASE + "/-/body/log/fat/date/%s.json" % datetime.date.today().strftime('%Y-%m-%d'))
+
     def test_friends(self):
         url = URLBASE + "/-/friends.json"
         self.common_api_test('get_friends', (), {}, (url,), {})


### PR DESCRIPTION
Hey there, 

This fixes #25, by adding `get_bodyweight` and `get_bodyfat` methods.

Both have test coverage, and I've aimed to match the existing style.  Tested, and working, here:

``` python
client.get_bodyweight()
>>> {u'weight': [{u'date': u'2014-03-29', u'logId': 1396089789000, u'bmi': 22.38, u'weight': 165, u'time': u'10:43:09'}, {u'date': u'2014-03-29', u'logId': 1396097620000, u'bmi': 22.41, u'weight': 165.3, u'time': u'12:53:40'}]}
client.get_bodyfat()
>>> {u'fat': [{u'date': u'2014-03-29', u'logId': 1396089789000, u'fat': 16.9, u'time': u'10:43:09'}, {u'date': u'2014-03-29', u'logId': 1396097620000, u'fat': 16.9, u'time': u'12:53:40'}]}
```

Threw in a version bump and tossed myself on AUTHORS since that's what I ask most people to do when they add PRs to my libs.

Cheers!
-Steven
