### PR TITLE
Support Fitbit API change about HTTPTooManyRequests

### DIFF
--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -13,7 +13,8 @@ from requests_oauthlib import OAuth1, OAuth1Session
 
 from fitbit.exceptions import (BadResponse, DeleteError, HTTPBadRequest,
                                HTTPUnauthorized, HTTPForbidden,
-                               HTTPServerError, HTTPConflict, HTTPNotFound)
+                               HTTPServerError, HTTPConflict, HTTPNotFound,
+                               HTTPTooManyRequests)
 from fitbit.utils import curry
 
 
@@ -83,6 +84,11 @@ class FitbitOauthClient(object):
             raise HTTPNotFound(response)
         elif response.status_code == 409:
             raise HTTPConflict(response)
+        elif response.status_code == 429:
+            exc = HTTPTooManyRequests(response)
+            exc.retry_after_secs = response.headers['Retry-After']
+            raise exc
+
         elif response.status_code >= 500:
             raise HTTPServerError(response)
         elif response.status_code >= 400:

--- a/fitbit/exceptions.py
+++ b/fitbit/exceptions.py
@@ -1,16 +1,19 @@
 import json
 
+
 class BadResponse(Exception):
     """
     Currently used if the response can't be json encoded, despite a .json extension
     """
     pass
 
+
 class DeleteError(Exception):
     """
     Used when a delete request did not return a 204
     """
     pass
+
 
 class HTTPException(Exception):
     def __init__(self, response, *args, **kwargs):
@@ -24,28 +27,44 @@ class HTTPException(Exception):
                 message = response
         super(HTTPException, self).__init__(message, *args, **kwargs)
 
+
 class HTTPBadRequest(HTTPException):
+    """Generic >= 400 error
+    """
     pass
 
 
 class HTTPUnauthorized(HTTPException):
+    """401
+    """
     pass
 
 
 class HTTPForbidden(HTTPException):
-    pass
-
-
-class HTTPServerError(HTTPException):
-    pass
-
-
-class HTTPConflict(HTTPException):
-    """
-    Used by Fitbit as rate limiter
+    """403
     """
     pass
 
 
 class HTTPNotFound(HTTPException):
+    """404
+    """
+    pass
+
+
+class HTTPConflict(HTTPException):
+    """409 - returned when creating conflicting resources
+    """
+    pass
+
+
+class HTTPTooManyRequests(HTTPException):
+    """429 - returned when exceeding rate limits
+    """
+    pass
+
+
+class HTTPServerError(HTTPException):
+    """Generic >= 500 error
+    """
     pass

--- a/fitbit_tests/test_exceptions.py
+++ b/fitbit_tests/test_exceptions.py
@@ -76,6 +76,19 @@ class ExceptionTest(unittest.TestCase):
         r.status_code = 499
         self.assertRaises(exceptions.HTTPBadRequest, f.user_profile_get)
 
+    def test_too_many_requests(self):
+        """
+        Tests the 429 response, given in case of exceeding the rate limit
+        """
+        r = mock.Mock(spec=requests.Response)
+        r.content = b"{'normal': 'resource'}"
+        r.headers = {'Retry-After': 10}
+
+        f = Fitbit(**self.client_kwargs)
+        f.client._request = lambda *args, **kwargs: r
+
+        r.status_code = 429
+        self.assertRaises(exceptions.HTTPTooManyRequests, f.user_profile_get)
 
     def test_serialization(self):
         """


### PR DESCRIPTION
This PR adds support for HTTPTooManyRequests error, that Fitbit will start using from May, 27th to signal the client that she exceeded her rate limit.  This improves compliance with RFC6585 (http://tools.ietf.org/html/rfc6585#section-4).

A HTTPTooManyRequests exception is added, and the Retry-After header content, which specifies how many seconds the client should wait before the next requests, is added to the exception as the `retry_after_secs` attribute.

This PR can be merged before May, 27th, because it's an incremental modification that doesn't break support of existing API.
