### PR TITLE
Convert retry-after header in seconds

### DIFF
--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -86,7 +86,7 @@ class FitbitOauthClient(object):
             raise HTTPConflict(response)
         elif response.status_code == 429:
             exc = HTTPTooManyRequests(response)
-            exc.retry_after_secs = response.headers['Retry-After']
+            exc.retry_after_secs = int(response.headers['Retry-After'])
             raise exc
 
         elif response.status_code >= 500:

--- a/fitbit_tests/test_exceptions.py
+++ b/fitbit_tests/test_exceptions.py
@@ -82,13 +82,15 @@ class ExceptionTest(unittest.TestCase):
         """
         r = mock.Mock(spec=requests.Response)
         r.content = b"{'normal': 'resource'}"
-        r.headers = {'Retry-After': 10}
+        r.headers = {'Retry-After': '10'}
 
         f = Fitbit(**self.client_kwargs)
         f.client._request = lambda *args, **kwargs: r
 
         r.status_code = 429
-        self.assertRaises(exceptions.HTTPTooManyRequests, f.user_profile_get)
+        with self.assertRaises(exceptions.HTTPTooManyRequests) as exc_ctx:
+            f.user_profile_get()
+        self.assertEqual(exc_ctx.exception.retry_after_secs, 10)
 
     def test_serialization(self):
         """
@@ -113,4 +115,3 @@ class ExceptionTest(unittest.TestCase):
         f = Fitbit(**self.client_kwargs)
         f.client._request = lambda *args, **kwargs: r
         self.assertRaises(exceptions.DeleteError, f.delete_activities, 12345)
-


### PR DESCRIPTION
Previous implementation passed the value through as string, but it makes more sense to convert it as integer as soon as it's received.  Add test coverage for this case extending an existing test.
