### PR TITLE
Added ability to pass an argument to the authorize_token_url call so the...

### DIFF
--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -107,14 +107,15 @@ class FitbitOauthClient(object):
         self.resource_owner_secret = token.get('oauth_token_secret')
         return token
 
-    def authorize_token_url(self):
+    def authorize_token_url(self, **kwargs):
         """Step 2: Return the URL the user needs to go to in order to grant us
         authorization to look at their data.  Then redirect the user to that
         URL, open their browser to it, or tell them to copy the URL into their
-        browser.
+        browser.  Allow the client to request the mobile display by passing
+        the display='touch' argument.
         """
 
-        return self.oauth.authorization_url(self.authorization_url)
+        return self.oauth.authorization_url(self.authorization_url, **kwargs)
 
     def fetch_access_token(self, verifier, token=None):
         """Step 3: Given the verifier from fitbit, and optionally a token from

--- a/fitbit_tests/test_auth.py
+++ b/fitbit_tests/test_auth.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from fitbit import Fitbit
+from fitbit import Fitbit, FitbitOauthClient
 import mock
 from requests_oauthlib import OAuth1Session
 
@@ -41,6 +41,12 @@ class AuthTest(TestCase):
             retval = fb.client.authorize_token_url()
             self.assertEqual(1, au.call_count)
             self.assertEqual("FAKEURL", retval)
+
+    def test_authorize_token_url_with_parameters(self):
+        # authorize_token_url calls oauth and returns a URL
+        client = FitbitOauthClient(**self.client_kwargs)
+        retval = client.authorize_token_url(display="touch")
+        self.assertTrue("display=touch" in retval)
 
     def test_fetch_access_token(self):
         kwargs = self.client_kwargs


### PR DESCRIPTION
... client can request the mobile version of the fitbit authorization.  Would make my users a load less squinty.  Tox tests pass for the versions of python I have installed:

``` python
  pypy: commands succeeded
  py34: commands succeeded
ERROR:   py33: InterpreterNotFound: python3.3
ERROR:   py32: InterpreterNotFound: python3.2
  py27: commands succeeded
  py26: commands succeeded
```
