### PR TITLE
api: support timeout kwarg to be handed down to requests

### DIFF
--- a/fitbit/exceptions.py
+++ b/fitbit/exceptions.py
@@ -15,6 +15,13 @@ class DeleteError(Exception):
     pass
 
 
+class Timeout(Exception):
+    """
+    Used when a timeout occurs.
+    """
+    pass
+
+
 class HTTPException(Exception):
     def __init__(self, response, *args, **kwargs):
         try:


### PR DESCRIPTION
Hi,

this pull request introduces support for a "timeout" keyword arg to be handed down to session.request().

It is good practice to use a timeout when using requests [1]. In fact, we have observed processes getting stuck forever in the session.request() call and had to regularly restart them. A new exception "Timeout" is added. It's the users responsibility to retry if this is required.
.
I'm happy to hear about suggestions or improvements.

Thanks,
   Arne

[1] http://docs.python-requests.org/en/master/user/advanced/#timeouts
