### PR TITLE
call a hook when tokens get refreshed

### DIFF
--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -29,7 +29,7 @@ class FitbitOauth2Client(object):
     refresh_token_url = request_token_url
 
     def __init__(self, client_id, client_secret,
-                 access_token=None, refresh_token=None,
+                 access_token=None, refresh_token=None, refresh_cb=None,
                  *args, **kwargs):
         """
         Create a FitbitOauth2Client object. Specify the first 7 parameters if
@@ -47,6 +47,7 @@ class FitbitOauth2Client(object):
             'access_token': access_token,
             'refresh_token': refresh_token
         }
+        self.refresh_cb = refresh_cb
         self.oauth = OAuth2Session(client_id)
 
     def _request(self, method, url, **kwargs):
@@ -162,6 +163,9 @@ class FitbitOauth2Client(object):
             refresh_token=self.token['refresh_token'],
             auth=requests.auth.HTTPBasicAuth(self.client_id, self.client_secret)
         )
+
+        if self.refresh_cb:
+            self.refresh_cb(self.token)
 
         return self.token
 

--- a/fitbit_tests/test_auth.py
+++ b/fitbit_tests/test_auth.py
@@ -65,9 +65,11 @@ class Auth2Test(TestCase):
         # 1. first call to _request causes a HTTPUnauthorized
         # 2. the token_refresh call is faked
         # 3. the second call to _request returns a valid value
+        refresh_cb = mock.MagicMock()
         kwargs = self.client_kwargs
         kwargs['access_token'] = 'fake_access_token'
         kwargs['refresh_token'] = 'fake_refresh_token'
+        kwargs['refresh_cb'] = refresh_cb
 
         fb = Fitbit(**kwargs)
         with mock.patch.object(FitbitOauth2Client, '_request') as r:
@@ -88,15 +90,18 @@ class Auth2Test(TestCase):
             "fake_return_refresh_token", fb.client.token['refresh_token'])
         self.assertEqual(1, rt.call_count)
         self.assertEqual(2, r.call_count)
+        refresh_cb.assert_called_once_with(rt.return_value)
 
     def test_auto_refresh_token_non_exception(self):
         """Test of auto_refersh when the exception doesn't fire"""
         # 1. first call to _request causes a 401 expired token response
         # 2. the token_refresh call is faked
         # 3. the second call to _request returns a valid value
+        refresh_cb = mock.MagicMock()
         kwargs = self.client_kwargs
         kwargs['access_token'] = 'fake_access_token'
         kwargs['refresh_token'] = 'fake_refresh_token'
+        kwargs['refresh_cb'] = refresh_cb
 
         fb = Fitbit(**kwargs)
         with mock.patch.object(FitbitOauth2Client, '_request') as r:
@@ -117,6 +122,7 @@ class Auth2Test(TestCase):
             "fake_return_refresh_token", fb.client.token['refresh_token'])
         self.assertEqual(1, rt.call_count)
         self.assertEqual(2, r.call_count)
+        refresh_cb.assert_called_once_with(rt.return_value)
 
 
 class fake_response(object):


### PR DESCRIPTION
@orcasgit/orcas-developers This allows the code using this API to specify a refresh callback that gets called whenever tokens are refresed and passes in the new token as an argument. As a proof of concept I've modified django-fitbit to use this callback:

https://github.com/orcasgit/django-fitbit/compare/refresh-callback?expand=1

That way the new tokens will be saved automatically any time (and with any call) the tokens get refreshed.
See also https://github.com/orcasgit/django-fitbit/issues/37