### PR TITLE
remove the ceiling of the dateutil package version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
-python-dateutil>=1.5,<2.5
+python-dateutil>=1.5
 requests-oauthlib>=0.6.1,<1.1


### PR DESCRIPTION
@orcasgit/orcas-developers Removes the upper version limit for dateutil. See https://github.com/orcasgit/python-fitbit/issues/106