### PR TITLE
Better error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@
 docs/_build
 *.egg-info
 *.egg
+.eggs
 dist
 build
 env
+htmlcov
 
 # Editors
 .idea

--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -141,15 +141,15 @@ class FitbitOauth2Client(object):
 
     def refresh_token(self):
         """Step 3: obtains a new access_token from the the refresh token
-        obtained in step 2.
-        the token is internally saved
+        obtained in step 2. Only do the refresh if there is `token_updater(),`
+        which saves the token.
         """
-        token = self.session.refresh_token(
-            self.refresh_token_url,
-            auth=HTTPBasicAuth(self.client_id, self.client_secret)
-        )
-
         if self.session.token_updater:
+
+            token = self.session.refresh_token(
+                self.refresh_token_url,
+                auth=HTTPBasicAuth(self.client_id, self.client_secret)
+            )
             self.session.token_updater(token)
 
         return token

--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -87,7 +87,14 @@ class FitbitOauth2Client(object):
         """
         data = data or {}
         method = method or ('POST' if data else 'GET')
-        response = self._request(method, url, data=data, **kwargs)
+        response = self._request(
+            method,
+            url,
+            data=data,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            **kwargs
+        )
 
         exceptions.detect_and_raise_error(response)
 

--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -10,8 +10,7 @@ except ImportError:
     from urllib import urlencode
 
 from requests.auth import HTTPBasicAuth
-from requests_oauthlib import OAuth2, OAuth2Session
-from oauthlib.oauth2.rfc6749.errors import TokenExpiredError
+from requests_oauthlib import OAuth2Session
 
 from . import exceptions
 from .compliance import fitbit_compliance_fix
@@ -144,7 +143,7 @@ class FitbitOauth2Client(object):
         obtained in step 2. Only do the refresh if there is `token_updater(),`
         which saves the token.
         """
-        token = None
+        token = {}
         if self.session.token_updater:
             token = self.session.refresh_token(
                 self.refresh_token_url,

--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -144,8 +144,8 @@ class FitbitOauth2Client(object):
         obtained in step 2. Only do the refresh if there is `token_updater(),`
         which saves the token.
         """
+        token = None
         if self.session.token_updater:
-
             token = self.session.refresh_token(
                 self.refresh_token_url,
                 auth=HTTPBasicAuth(self.client_id, self.client_secret)

--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -133,28 +133,26 @@ class FitbitOauth2Client(object):
         """
         if redirect_uri:
             self.session.redirect_uri = redirect_uri
-        self.session.fetch_token(
+        return self.session.fetch_token(
             self.access_token_url,
             username=self.client_id,
             password=self.client_secret,
             code=code)
-
-        return self.session.token
 
     def refresh_token(self):
         """Step 3: obtains a new access_token from the the refresh token
         obtained in step 2.
         the token is internally saved
         """
-        self.session.refresh_token(
+        token = self.session.refresh_token(
             self.refresh_token_url,
             auth=HTTPBasicAuth(self.client_id, self.client_secret)
         )
 
         if self.session.token_updater:
-            self.session.token_updater(self.session.token)
+            self.session.token_updater(token)
 
-        return self.session.token
+        return token
 
 
 class Fitbit(object):

--- a/fitbit/compliance.py
+++ b/fitbit/compliance.py
@@ -1,0 +1,26 @@
+"""
+The Fitbit API breaks from the OAuth2 RFC standard by returning an "errors"
+object list, rather than a single "error" string. This puts hooks in place so
+that oauthlib can process an error in the results from access token and refresh
+token responses. This is necessary to prevent getting the generic red herring
+MissingTokenError.
+"""
+
+from json import loads, dumps
+
+from oauthlib.common import to_unicode
+
+
+def fitbit_compliance_fix(session):
+
+    def _missing_error(r):
+        token = loads(r.text)
+        if 'errors' in token:
+            # Set the error to the first one we have
+            token['error'] = token['errors'][0]['errorType']
+        r._content = to_unicode(dumps(token)).encode('UTF-8')
+        return r
+
+    session.register_compliance_hook('access_token_response', _missing_error)
+    session.register_compliance_hook('refresh_token_response', _missing_error)
+    return session

--- a/fitbit/exceptions.py
+++ b/fitbit/exceptions.py
@@ -75,3 +75,22 @@ class HTTPServerError(HTTPException):
     """Generic >= 500 error
     """
     pass
+
+
+def detect_and_raise_error(response):
+    if response.status_code == 401:
+        raise HTTPUnauthorized(response)
+    elif response.status_code == 403:
+        raise HTTPForbidden(response)
+    elif response.status_code == 404:
+        raise HTTPNotFound(response)
+    elif response.status_code == 409:
+        raise HTTPConflict(response)
+    elif response.status_code == 429:
+        exc = HTTPTooManyRequests(response)
+        exc.retry_after_secs = int(response.headers['Retry-After'])
+        raise exc
+    elif response.status_code >= 500:
+        raise HTTPServerError(response)
+    elif response.status_code >= 400:
+        raise HTTPBadRequest(response)

--- a/fitbit_tests/test_auth.py
+++ b/fitbit_tests/test_auth.py
@@ -29,14 +29,13 @@ class Auth2Test(TestCase):
     def test_authorize_token_url(self):
         # authorize_token_url calls oauth and returns a URL
         fb = Fitbit(**self.client_kwargs)
-        retval = fb.client.authorize_token_url('http://127.0.0.1:8080')
+        retval = fb.client.authorize_token_url()
         self.assertEqual(retval[0], 'https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=fake_id&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080&scope=activity+nutrition+heartrate+location+nutrition+profile+settings+sleep+social+weight&state='+retval[1])
 
     def test_authorize_token_url_with_scope(self):
         # authorize_token_url calls oauth and returns a URL
         fb = Fitbit(**self.client_kwargs)
-        retval = fb.client.authorize_token_url(
-            'http://127.0.0.1:8080', scope=self.client_kwargs['scope'])
+        retval = fb.client.authorize_token_url(scope=self.client_kwargs['scope'])
         self.assertEqual(retval[0], 'https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=fake_id&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080&scope='+ str(self.client_kwargs['scope'][0])+ '&state='+retval[1])
 
     def test_fetch_access_token(self):

--- a/fitbit_tests/test_auth.py
+++ b/fitbit_tests/test_auth.py
@@ -6,11 +6,9 @@ import requests_mock
 from datetime import datetime
 from freezegun import freeze_time
 from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
-from requests_oauthlib import OAuth2Session
 from unittest import TestCase
 
-from fitbit import Fitbit, FitbitOauth2Client
-from fitbit.exceptions import HTTPUnauthorized
+from fitbit import Fitbit
 
 
 class Auth2Test(TestCase):
@@ -56,6 +54,7 @@ class Auth2Test(TestCase):
         kwargs = copy.copy(self.client_kwargs)
         kwargs['access_token'] = 'fake_access_token'
         kwargs['refresh_token'] = 'fake_refresh_token'
+        kwargs['refresh_cb'] = lambda x: None
         fb = Fitbit(**kwargs)
         with requests_mock.mock() as m:
             m.post(fb.client.refresh_token_url, text=json.dumps({

--- a/fitbit_tests/test_auth.py
+++ b/fitbit_tests/test_auth.py
@@ -1,8 +1,16 @@
+import copy
+import json
+import mock
+import requests_mock
+
+from datetime import datetime
+from freezegun import freeze_time
+from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
+from requests_oauthlib import OAuth2Session
 from unittest import TestCase
+
 from fitbit import Fitbit, FitbitOauth2Client
 from fitbit.exceptions import HTTPUnauthorized
-import mock
-from requests_oauthlib import OAuth2Session
 
 
 class Auth2Test(TestCase):
@@ -14,51 +22,85 @@ class Auth2Test(TestCase):
     client_kwargs = {
         'client_id': 'fake_id',
         'client_secret': 'fake_secret',
-        'callback_uri': 'fake_callback_url',
+        'redirect_uri': 'http://127.0.0.1:8080',
         'scope': ['fake_scope1']
     }
 
     def test_authorize_token_url(self):
         # authorize_token_url calls oauth and returns a URL
         fb = Fitbit(**self.client_kwargs)
-        retval = fb.client.authorize_token_url()
-        self.assertEqual(retval[0], 'https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=fake_id&scope=activity+nutrition+heartrate+location+nutrition+profile+settings+sleep+social+weight&state='+retval[1])
+        retval = fb.client.authorize_token_url('http://127.0.0.1:8080')
+        self.assertEqual(retval[0], 'https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=fake_id&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080&scope=activity+nutrition+heartrate+location+nutrition+profile+settings+sleep+social+weight&state='+retval[1])
 
-    def test_authorize_token_url_with_parameters(self):
+    def test_authorize_token_url_with_scope(self):
         # authorize_token_url calls oauth and returns a URL
         fb = Fitbit(**self.client_kwargs)
         retval = fb.client.authorize_token_url(
-            scope=self.client_kwargs['scope'],
-            callback_uri=self.client_kwargs['callback_uri'])
-        self.assertEqual(retval[0], 'https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=fake_id&scope='+ str(self.client_kwargs['scope'][0])+ '&state='+retval[1]+'&callback_uri='+self.client_kwargs['callback_uri'])
+            'http://127.0.0.1:8080', scope=self.client_kwargs['scope'])
+        self.assertEqual(retval[0], 'https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=fake_id&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080&scope='+ str(self.client_kwargs['scope'][0])+ '&state='+retval[1])
 
     def test_fetch_access_token(self):
         # tests the fetching of access token using code and redirect_URL
         fb = Fitbit(**self.client_kwargs)
         fake_code = "fake_code"
-        with mock.patch.object(OAuth2Session, 'fetch_token') as fat:
-            fat.return_value = {
+        with requests_mock.mock() as m:
+            m.post(fb.client.access_token_url, text=json.dumps({
                 'access_token': 'fake_return_access_token',
                 'refresh_token': 'fake_return_refresh_token'
-            }
-            retval = fb.client.fetch_access_token(fake_code, self.client_kwargs['callback_uri'])
+            }))
+            retval = fb.client.fetch_access_token(fake_code)
         self.assertEqual("fake_return_access_token", retval['access_token'])
         self.assertEqual("fake_return_refresh_token", retval['refresh_token'])
 
     def test_refresh_token(self):
         # test of refresh function
-        kwargs = self.client_kwargs
+        kwargs = copy.copy(self.client_kwargs)
         kwargs['access_token'] = 'fake_access_token'
         kwargs['refresh_token'] = 'fake_refresh_token'
         fb = Fitbit(**kwargs)
-        with mock.patch.object(OAuth2Session, 'refresh_token') as rt:
-            rt.return_value = {
+        with requests_mock.mock() as m:
+            m.post(fb.client.refresh_token_url, text=json.dumps({
                 'access_token': 'fake_return_access_token',
                 'refresh_token': 'fake_return_refresh_token'
-            }
+            }))
             retval = fb.client.refresh_token()
         self.assertEqual("fake_return_access_token", retval['access_token'])
         self.assertEqual("fake_return_refresh_token", retval['refresh_token'])
+
+    @freeze_time(datetime.fromtimestamp(1483563319))
+    def test_auto_refresh_expires_at(self):
+        """Test of auto_refresh with expired token"""
+        # 1. first call to _request causes a HTTPUnauthorized
+        # 2. the token_refresh call is faked
+        # 3. the second call to _request returns a valid value
+        refresh_cb = mock.MagicMock()
+        kwargs = copy.copy(self.client_kwargs)
+        kwargs.update({
+            'access_token': 'fake_access_token',
+            'refresh_token': 'fake_refresh_token',
+            'expires_at': 1483530000,
+            'refresh_cb': refresh_cb,
+        })
+
+        fb = Fitbit(**kwargs)
+        profile_url = Fitbit.API_ENDPOINT + '/1/user/-/profile.json'
+        with requests_mock.mock() as m:
+            m.get(
+                profile_url,
+                text='{"user":{"aboutMe": "python-fitbit developer"}}',
+                status_code=200
+            )
+            token = {
+                'access_token': 'fake_return_access_token',
+                'refresh_token': 'fake_return_refresh_token',
+                'expires_at': 1483570000,
+            }
+            m.post(fb.client.refresh_token_url, text=json.dumps(token))
+            retval = fb.make_request(profile_url)
+        self.assertEqual(retval['user']['aboutMe'], "python-fitbit developer")
+        self.assertEqual("fake_return_access_token", token['access_token'])
+        self.assertEqual("fake_return_refresh_token", token['refresh_token'])
+        refresh_cb.assert_called_once_with(token)
 
     def test_auto_refresh_token_exception(self):
         """Test of auto_refresh with Unauthorized exception"""
@@ -66,63 +108,58 @@ class Auth2Test(TestCase):
         # 2. the token_refresh call is faked
         # 3. the second call to _request returns a valid value
         refresh_cb = mock.MagicMock()
-        kwargs = self.client_kwargs
-        kwargs['access_token'] = 'fake_access_token'
-        kwargs['refresh_token'] = 'fake_refresh_token'
-        kwargs['refresh_cb'] = refresh_cb
+        kwargs = copy.copy(self.client_kwargs)
+        kwargs.update({
+            'access_token': 'fake_access_token',
+            'refresh_token': 'fake_refresh_token',
+            'refresh_cb': refresh_cb,
+        })
 
         fb = Fitbit(**kwargs)
-        with mock.patch.object(FitbitOauth2Client, '_request') as r:
-            r.side_effect = [
-                HTTPUnauthorized(fake_response(401, b'correct_response')),
-                fake_response(200, 'correct_response')
-            ]
-            with mock.patch.object(OAuth2Session, 'refresh_token') as rt:
-                rt.return_value = {
-                    'access_token': 'fake_return_access_token',
-                    'refresh_token': 'fake_return_refresh_token'
-                }
-                retval = fb.client.make_request(Fitbit.API_ENDPOINT + '/1/user/-/profile.json')
-        self.assertEqual("correct_response", retval.text)
-        self.assertEqual(
-            "fake_return_access_token", fb.client.token['access_token'])
-        self.assertEqual(
-            "fake_return_refresh_token", fb.client.token['refresh_token'])
-        self.assertEqual(1, rt.call_count)
-        self.assertEqual(2, r.call_count)
-        refresh_cb.assert_called_once_with(rt.return_value)
+        profile_url = Fitbit.API_ENDPOINT + '/1/user/-/profile.json'
+        with requests_mock.mock() as m:
+            m.get(profile_url, [{
+                'text': json.dumps({
+                    "errors": [{
+                        "errorType": "expired_token",
+                        "message": "Access token expired:"
+                    }]
+                }),
+                'status_code': 401
+            }, {
+                'text': '{"user":{"aboutMe": "python-fitbit developer"}}',
+                'status_code': 200
+            }])
+            token = {
+                'access_token': 'fake_return_access_token',
+                'refresh_token': 'fake_return_refresh_token'
+            }
+            m.post(fb.client.refresh_token_url, text=json.dumps(token))
+            retval = fb.make_request(profile_url)
+        self.assertEqual(retval['user']['aboutMe'], "python-fitbit developer")
+        self.assertEqual("fake_return_access_token", token['access_token'])
+        self.assertEqual("fake_return_refresh_token", token['refresh_token'])
+        refresh_cb.assert_called_once_with(token)
 
-    def test_auto_refresh_token_non_exception(self):
-        """Test of auto_refersh when the exception doesn't fire"""
-        # 1. first call to _request causes a 401 expired token response
-        # 2. the token_refresh call is faked
-        # 3. the second call to _request returns a valid value
+    def test_auto_refresh_error(self):
+        """Test of auto_refresh with expired refresh token"""
+
         refresh_cb = mock.MagicMock()
-        kwargs = self.client_kwargs
-        kwargs['access_token'] = 'fake_access_token'
-        kwargs['refresh_token'] = 'fake_refresh_token'
-        kwargs['refresh_cb'] = refresh_cb
+        kwargs = copy.copy(self.client_kwargs)
+        kwargs.update({
+            'access_token': 'fake_access_token',
+            'refresh_token': 'fake_refresh_token',
+            'refresh_cb': refresh_cb,
+        })
 
         fb = Fitbit(**kwargs)
-        with mock.patch.object(FitbitOauth2Client, '_request') as r:
-            r.side_effect = [
-                fake_response(401, b'{"errors": [{"message": "Access token expired: some_token_goes_here", "errorType": "expired_token", "fieldName": "access_token"}]}'),
-                fake_response(200, 'correct_response')
-            ]
-            with mock.patch.object(OAuth2Session, 'refresh_token') as rt:
-                rt.return_value = {
-                    'access_token': 'fake_return_access_token',
-                    'refresh_token': 'fake_return_refresh_token'
-                }
-                retval = fb.client.make_request(Fitbit.API_ENDPOINT + '/1/user/-/profile.json')
-        self.assertEqual("correct_response", retval.text)
-        self.assertEqual(
-            "fake_return_access_token", fb.client.token['access_token'])
-        self.assertEqual(
-            "fake_return_refresh_token", fb.client.token['refresh_token'])
-        self.assertEqual(1, rt.call_count)
-        self.assertEqual(2, r.call_count)
-        refresh_cb.assert_called_once_with(rt.return_value)
+        with requests_mock.mock() as m:
+            response = {
+                "errors": [{"errorType": "invalid_grant"}],
+                "success": False
+            }
+            m.post(fb.client.refresh_token_url, text=json.dumps(response))
+            self.assertRaises(InvalidGrantError, fb.client.refresh_token)
 
 
 class fake_response(object):

--- a/fitbit_tests/test_auth.py
+++ b/fitbit_tests/test_auth.py
@@ -6,6 +6,7 @@ import requests_mock
 from datetime import datetime
 from freezegun import freeze_time
 from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
+from requests.auth import _basic_auth_str
 from unittest import TestCase
 
 from fitbit import Fitbit
@@ -95,6 +96,15 @@ class Auth2Test(TestCase):
             }
             m.post(fb.client.refresh_token_url, text=json.dumps(token))
             retval = fb.make_request(profile_url)
+
+        self.assertEqual(m.request_history[0].path, '/oauth2/token')
+        self.assertEqual(
+            m.request_history[0].headers['Authorization'],
+            _basic_auth_str(
+                self.client_kwargs['client_id'],
+                self.client_kwargs['client_secret']
+            )
+        )
         self.assertEqual(retval['user']['aboutMe'], "python-fitbit developer")
         self.assertEqual("fake_return_access_token", token['access_token'])
         self.assertEqual("fake_return_refresh_token", token['refresh_token'])
@@ -134,6 +144,15 @@ class Auth2Test(TestCase):
             }
             m.post(fb.client.refresh_token_url, text=json.dumps(token))
             retval = fb.make_request(profile_url)
+
+        self.assertEqual(m.request_history[1].path, '/oauth2/token')
+        self.assertEqual(
+            m.request_history[1].headers['Authorization'],
+            _basic_auth_str(
+                self.client_kwargs['client_id'],
+                self.client_kwargs['client_secret']
+            )
+        )
         self.assertEqual(retval['user']['aboutMe'], "python-fitbit developer")
         self.assertEqual("fake_return_access_token", token['access_token'])
         self.assertEqual("fake_return_refresh_token", token['refresh_token'])

--- a/gather_keys_oauth2.py
+++ b/gather_keys_oauth2.py
@@ -24,7 +24,8 @@ class OAuth2Server:
         self.fitbit = Fitbit(
             client_id,
             client_secret,
-            redirect_uri=redirect_uri
+            redirect_uri=redirect_uri,
+            timeout=10,
         )
 
     def browser_authorize(self):

--- a/gather_keys_oauth2.py
+++ b/gather_keys_oauth2.py
@@ -15,21 +15,24 @@ class OAuth2Server:
     def __init__(self, client_id, client_secret,
                  redirect_uri='http://127.0.0.1:8080/'):
         """ Initialize the FitbitOauth2Client """
-        self.redirect_uri = redirect_uri
         self.success_html = """
             <h1>You are now authorized to access the Fitbit API!</h1>
             <br/><h3>You can close this window</h3>"""
         self.failure_html = """
             <h1>ERROR: %s</h1><br/><h3>You can close this window</h3>%s"""
 
-        self.fitbit = Fitbit(client_id, client_secret)
+        self.fitbit = Fitbit(
+            client_id,
+            client_secret,
+            redirect_uri=redirect_uri
+        )
 
     def browser_authorize(self):
         """
         Open a browser to the authorization url and spool up a CherryPy
         server to accept the response
         """
-        url, _ = self.fitbit.client.authorize_token_url(self.redirect_uri)
+        url, _ = self.fitbit.client.authorize_token_url()
         # Open the web browser in a new thread for command-line browser support
         threading.Timer(1, webbrowser.open, args=(url,)).start()
         cherrypy.quickstart(self)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
 python-dateutil>=1.5
-requests-oauthlib>=0.6.1,<1.1
+requests-oauthlib>=0.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,5 @@
-mock>=1.0,<1.4
 coverage>=3.7,<4.0
+freezegun>=0.3.8
+mock>=1.0
+requests-mock>=1.2.0
 Sphinx>=1.2,<1.4


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This utilizes the requests-oauthlib library a bit better, enabling auto-refresh if the expires_at attribute has been set, and letting it handle some of the auth headers more. I also enabled a compliance hook that lets requests-oauthlib see the errors in fetch and refresh responses so it will throw the proper exception. There are a few other refactors as well, but it should be entirely backward compatible.