### PR TITLE
Remove parameter assignment

### DIFF
--- a/gather_keys_oauth2.py
+++ b/gather_keys_oauth2.py
@@ -24,7 +24,7 @@ class OAuth2Server:
         self.fitbit = Fitbit(
             client_id,
             client_secret,
-            redirect_uri=redirect_uri,
+            redirect_uri,
             timeout=10,
         )
 


### PR DESCRIPTION
I was trying to get authorized but Fitbit server spitted out an error that redirect_uri is giving bad arguments. I figured out giving redirect_uri parameter is duplicated to original field. It should be given as the user set. Just using that given argument as a field.