### PR TITLE
added support for get-sleep-logs-by-date-range

### DIFF
--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -800,11 +800,27 @@ class Fitbit(object):
         https://dev.fitbit.com/docs/sleep/#get-sleep-logs
         date should be a datetime.date object.
         """
-        url = "{0}/{1}/user/-/sleep/date/{year}-{month}-{day}.json".format(
+        url = "{0}/{1}/user/-/sleep/date/{year:04d}-{month:02d}-{day:02d}.json".format(
             *self._get_common_args(),
             year=date.year,
             month=date.month,
             day=date.day
+        )
+        return self.make_request(url)
+
+    def get_sleep_range(self, date1, date2):
+        """
+        https://dev.fitbit.com/docs/sleep/#get-sleep-logs-by-date-range
+        date1 and date2 should be datetime.date objects.
+        """
+        url = "{0}/{1}/user/-/sleep/date/{year1:04d}-{month1:02d}-{day1:02d}/{year2:04d}-{month2:02d}-{day2:02d}.json".format(
+            *self._get_common_args(),
+            year1=date1.year,
+            month1=date1.month,
+            day1=date1.day,
+            year2=date2.year,
+            month2=date2.month,
+            day2=date2.day
         )
         return self.make_request(url)
 

--- a/fitbit_tests/test_api.py
+++ b/fitbit_tests/test_api.py
@@ -417,6 +417,13 @@ class ResourceAccessTest(TestBase):
         self.common_api_test('sleep', (today,), {}, ("%s/-/sleep/date/%s.json" % (URLBASE, today), None), {})
         self.common_api_test('sleep', (today, "USER_ID"), {}, ("%s/USER_ID/sleep/date/%s.json" % (URLBASE, today), None), {})
 
+    def test_sleep_range(self):
+        today = datetime.date.today()
+        today_s = today.strftime('%Y-%m-%d')
+        yesterday = (datetime.date.today()-datetime.timedelta(hours=24))
+        yesterday_s = yesterday.strftime('%Y-%m-%d')
+        self.common_api_test('get_sleep_range', (yesterday, today), {}, ("%s/-/sleep/date/%s/%s.json" % (URLBASE, yesterday_s, today_s),), {})
+
     def test_foods(self):
         today = datetime.date.today().strftime('%Y-%m-%d')
         self.common_api_test('recent_foods', ("USER_ID",), {}, (URLBASE+"/USER_ID/foods/log/recent.json",), {})


### PR DESCRIPTION
this teaches fitbit.Fitbit about get_sleep_range, which provides
access to
https://dev.fitbit.com/docs/sleep/#get-sleep-logs-by-date-range. I
wasn't sure how to fit this into the existing COLLECTION_RESOURCE
framework, but I'm happy to make changes.