### PR TITLE
Added a print statement to clarify procedures in the command line if …

### DIFF
--- a/gather_keys_oauth2.py
+++ b/gather_keys_oauth2.py
@@ -34,6 +34,9 @@ class OAuth2Server:
         server to accept the response
         """
         url, _ = self.fitbit.client.authorize_token_url()
+        print('If the authorization page was not loaded automatically, '
+              'enter the following url into the address bar: '
+              '\n {}'.format(url))
         # Open the web browser in a new thread for command-line browser support
         threading.Timer(1, webbrowser.open, args=(url,)).start()
         cherrypy.quickstart(self)


### PR DESCRIPTION
…the authorization page is not loaded.

When using the gather_keys_oauth2 script, the web browser was not redirecting as expected and no additional information was given in the command line. I entered a print statement so I could copy this URL into the browser, after which I was able to successfully get my keys. No core functionality was changed, and all 51 tests still passed. 