### PR TITLE
 Backported headless mode from praveendath92/fitbit-googlefit

### DIFF
--- a/gather_keys_oauth2.py
+++ b/gather_keys_oauth2.py
@@ -64,14 +64,7 @@ class OAuth2Server:
         """
         error = None
         if code:
-            try:
-                self.fitbit.client.fetch_access_token(code)
-            except MissingTokenError:
-                error = self._fmt_failure(
-                    'Missing access token parameter.</br>Please check that '
-                    'you are using the correct client_secret')
-            except MismatchingStateError:
-                error = self._fmt_failure('CSRF Warning! Mismatching state')
+            self.authenticate_code(code=code)
         else:
             error = self._fmt_failure('Unknown error while authenticating')
         # Use a thread to shutdown cherrypy so we can return HTML first

--- a/gather_keys_oauth2.py
+++ b/gather_keys_oauth2.py
@@ -9,7 +9,8 @@ import webbrowser
 from base64 import b64encode
 from fitbit.api import Fitbit
 from oauthlib.oauth2.rfc6749.errors import MismatchingStateError, MissingTokenError
-
+import urllib.parse as urlparse
+import argparse
 
 class OAuth2Server:
     def __init__(self, client_id, client_secret,
@@ -38,6 +39,23 @@ class OAuth2Server:
         threading.Timer(1, webbrowser.open, args=(url,)).start()
         cherrypy.quickstart(self)
 
+    def headless_authorize(self):
+        """
+        Authorize without a display using only TTY.
+        """
+        url, _ = self.fitbit.client.authorize_token_url()
+        # Ask the user to open this url on a system with browser
+        print('\n-------------------------------------------------------------------------')
+        print('\t\tOpen the below URL in your browser\n')
+        print(url)
+        print('\n-------------------------------------------------------------------------\n')
+        print('NOTE: After authenticating on Fitbit website, you will redirected to a URL which ')
+        print('throws an ERROR. This is expected! Just copy the full redirected here.\n')
+        redirected_url = input('Full redirected URL: ')
+        params = urlparse.parse_qs(urlparse.urlparse(redirected_url).query)
+        print(params['code'][0])
+        self.authenticate_code(code=params['code'][0])
+
     @cherrypy.expose
     def index(self, state, code=None, error=None):
         """
@@ -65,6 +83,20 @@ class OAuth2Server:
         tb_html = '<pre>%s</pre>' % ('\n'.join(tb)) if tb else ''
         return self.failure_html % (message, tb_html)
 
+    def authenticate_code(self, code=None):
+        """
+        Final stage of authentication using the code from Fitbit.
+        """
+        try:
+            self.fitbit.client.fetch_access_token(code)
+        except MissingTokenError:
+            error = self._fmt_failure(
+                'Missing access token parameter.</br>Please check that '
+                'you are using the correct client_secret'
+            )
+        except MismatchingStateError:
+            error = self._fmt_failure('CSRF Warning! Mismatching state')
+
     def _shutdown_cherrypy(self):
         """ Shutdown cherrypy in one second, if it's running """
         if cherrypy.engine.state == cherrypy.engine.states.STARTED:
@@ -73,12 +105,20 @@ class OAuth2Server:
 
 if __name__ == '__main__':
 
-    if not (len(sys.argv) == 3):
-        print("Arguments: client_id and client_secret")
-        sys.exit(1)
+    # Arguments parsing
+    parser = argparse.ArgumentParser("Client ID and Secret are mandatory arguments")
+    parser.add_argument("-i", "--id", required=True, help="Client id", metavar='<client-id>')
+    parser.add_argument("-s", "--secret", required=True, help="Client secret", 
+        metavar='<client-secret>')
+    parser.add_argument("-c", "--console", default=False, 
+        help="Authenticate only using console (for headless systems)", action="store_true")
+    args = parser.parse_args()
 
-    server = OAuth2Server(*sys.argv[1:])
-    server.browser_authorize()
+    server = OAuth2Server(args.id, args.secret)
+    if args.console:
+        server.headless_authorize()
+    else:   
+        server.browser_authorize()
 
     profile = server.fitbit.user_profile_get()
     print('You are authorized to access data for the user: {}'.format(


### PR DESCRIPTION
A modified version of this file is used by the repo [praveendath92/fitbit-googlefit](https://github.com/praveendath92/fitbit-googlefit).

One of the modification allows keys to be gathered in headless mode which is very useful if your script is running on another server such as a raspberry pi. I've reflected the changes from [praveendath92/fitbit-googlefit #16](https://github.com/praveendath92/fitbit-googlefit/issues/16) with the only breaking changes being to the CLI where flags now dictate the client_id, client_secret and headless mode for which the docs may need updating.