### PR TITLE
Update fetch_token because things seem to have changed for authorization

### DIFF
--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -141,8 +141,8 @@ class FitbitOauth2Client(object):
             self.session.redirect_uri = redirect_uri
         return self.session.fetch_token(
             self.access_token_url,
-            username=self.client_id,
-            password=self.client_secret,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
             code=code)
 
     def refresh_token(self):


### PR DESCRIPTION
So there seems to be this issue with the requests oauth where it wasn't correctly encoding the authorization headers. When I patched my copy of the library to use client_id and client_secret I got back a different error that was related to the code.