### PR TITLE
pass client_secret kwarg to fetch method

### DIFF
--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -143,6 +143,7 @@ class FitbitOauth2Client(object):
             self.access_token_url,
             username=self.client_id,
             password=self.client_secret,
+            client_secret=self.client_secret,
             code=code)
 
     def refresh_token(self):


### PR DESCRIPTION
This adds the client_secret kwarg to the fetch_token, making us compatible with newer versions of the oauth libraries, while retaining backward compatibility as much as possible.