### PR TITLE
METRIC="en_UK" is incorrect or at least confusing.

### DIFF
--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -185,7 +185,8 @@ class Fitbit(object):
     that is to reauthorize the user.
     """
     US = 'en_US'
-    METRIC = 'en_UK'
+    UK = 'en_GB'
+    METRIC = ' '
 
     API_ENDPOINT = "https://api.fitbit.com"
     API_VERSION = 1


### PR DESCRIPTION
I just wanted to point out that it is confusing to have 

US = 'en_US'
METRIC = 'en_UK'

because the only reason 'en_UK' gets you metric is because it is an incorrect form of what I'd assume is supposed to be 'en_GB', the language tag for British English. Also, this is confusing because the 'en_GB' tag isn't metric but British (so it uses stones, for example).

See here: https://dev.fitbit.com/build/reference/web-api/basics/#units