### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Requirements
 * Python 2.7+
 * `python-dateutil`_ (always)
 * `requests-oauthlib`_ (always)
-* `Sphinx`_ (to create the documention)
+* `Sphinx`_ (to create the documentation)
 * `tox`_ (for running the tests)
 * `coverage`_ (to create test coverage reports)
 

--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -105,7 +105,7 @@ class FitbitOauth2Client(object):
         authorization to look at their data.  Then redirect the user to that
         URL, open their browser to it, or tell them to copy the URL into their
         browser.
-            - scope: pemissions that that are being requested [default ask all]
+            - scope: permissions that that are being requested [default ask all]
             - redirect_uri: url to which the response will posted. required here
               unless you specify only one Callback URL on the fitbit app or
               you already passed it to the constructor


### PR DESCRIPTION
There are small typos in:
- README.rst
- fitbit/api.py

Fixes:
- Should read `permissions` rather than `pemissions`.
- Should read `documentation` rather than `documention`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md