### PR TITLE
Update api.py

### DIFF
--- a/fitbit/api.py
+++ b/fitbit/api.py
@@ -801,7 +801,7 @@ class Fitbit(object):
         https://dev.fitbit.com/docs/sleep/#get-sleep-logs
         date should be a datetime.date object.
         """
-        url = "{0}/{1}/user/-/sleep/date/{year}-{month}-{day}.json".format(
+        url = "{0}/1.2/user/-/sleep/date/{year}-{month}-{day}.json".format(
             *self._get_common_args(),
             year=date.year,
             month=date.month,


### PR DESCRIPTION
The version of sleep endpoint is now 1.2 instead of 1 (with other endpoints inchanged). Using the old endpoints will not get the sleep stage correctly. 
Please see details on 
https://dev.fitbit.com/build/reference/web-api/sleep-v1/
https://dev.fitbit.com/build/reference/web-api/sleep/