### PR TITLE
Remove setuptools from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=['fitbit'],
     package_data={'': ['LICENSE']},
     include_package_data=True,
-    install_requires=["setuptools"] + required,
+    install_requires=required,
     license='Apache 2.0',
     test_suite='fitbit_tests.all_tests',
     tests_require=required_test,


### PR DESCRIPTION
I believe setuptools is redundant here.

Two reasons for that:
1. There are no mentions of setuptools (or other things distributed with it) in the code 
2. If I build a wheel manually and than install it in a separate environment with no setuptools - not only it is installed successfully, but also importing `fitbit` and running some code (e.g. `Fitbit.time_series`) succeeds
